### PR TITLE
Rename `write_df()` to `write_data_file()`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,12 +48,6 @@ repos:
     rev: 6.1.1
     hooks:
       - id: pydocstyle
-        # D100: Missing docstring in public module
-        # D104: Missing docstring in public package
-        # D107: Missing docstring in __init__
-        # D205: 1 blank line required between summary line and description
-        # D415: First line should end with ., ? or !
-        args: [--convention=google, '--add-ignore=D100,D104,D107,D205,D415']
         exclude: tests
 
   - repo: https://github.com/codespell-project/codespell

--- a/assets/python_api_example.ipynb
+++ b/assets/python_api_example.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -25,17 +25,25 @@
     }
    ],
    "source": [
-    "# where are your TensorBoard event files saved?\n",
-    "in_dirs = glob(\"../tests/runs/strict/*\")\n",
+    "# where are your TensorBoard event files stored?\n",
+    "input_event_dirs = glob(\"../tests/runs/strict/*\")\n",
     "\n",
-    "print(f\"Found {len(in_dirs)} runs: {in_dirs}\")"
+    "print(f\"Found {len(input_event_dirs)} runs: {input_event_dirs}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/janosh/.venv/py310/lib/python3.10/site-packages/h5py/__init__.py:36: UserWarning: h5py is running against HDF5 1.12.2 when it was built against 1.12.1, this may cause problems\n",
+      "  _warn((\"h5py is running against HDF5 {0} when it was built against {1}, \"\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -62,10 +70,10 @@
    "source": [
     "events_out_dir = \"./tmp/strict\"\n",
     "csv_out_path = \"./tmp/tb-reduction.csv\"\n",
-    "overwrite = False\n",
+    "overwrite = True\n",
     "reduce_ops = (\"mean\", \"min\", \"max\")\n",
     "\n",
-    "events_dict = tbr.load_tb_events(in_dirs)\n",
+    "events_dict = tbr.load_tb_events(input_event_dirs)\n",
     "\n",
     "n_scalars = len(events_dict)\n",
     "n_steps, n_events = list(events_dict.values())[0].shape\n",
@@ -78,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -103,7 +111,7 @@
     "\n",
     "print(f\"Writing results to '{csv_out_path}'\")\n",
     "\n",
-    "tbr.write_df(reduced_events, csv_out_path, overwrite)\n",
+    "tbr.write_data_file(reduced_events, csv_out_path, overwrite)\n",
     "\n",
     "print(\"Reduction complete\")"
    ]
@@ -128,7 +136,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.10.5"
   },
   "orig_nbformat": 4
  },

--- a/readme.md
+++ b/readme.md
@@ -48,22 +48,22 @@ In addition, `tb-reducer` has the following flags:
 
 ### Python API
 
-You can also import `tensorboard_reducer` into a Python script for more complex operations. A simple example that makes use of the full Python API (`load_tb_events`, `reduce_events`, `write_csv`, `write_tb_events`) to get you started:
+You can also import `tensorboard_reducer` into a Python script or Jupyter notebook for more complex operations. Here's a simple example that uses all of the main functions [`load_tb_events`], [`reduce_events`], [`write_data_file`] and [`write_tb_events`] to get you started:
 
 ```py
 from glob import glob
 
 import tensorboard_reducer as tbr
 
-in_dirs = glob("glob_pattern/of_directories_to_reduce*")
-events_out_dir = "path/to/output_dir"
-csv_out_path = "path/to/out.csv"
-overwrite = False
+input_event_dirs = glob("glob_pattern/of_tb_directories_to_reduce*")
+tb_events_output_dir = "path/to/output_dir"  # where to write reduced TB events, each reduce operation will be in a separate subdirectory
+csv_out_path = "path/to/write/reduced-data-as.csv"
+overwrite = False  # whether to abort or overwrite when csv_out_path already exists
 reduce_ops = ("mean", "min", "max")
 
-events_dict = tbr.load_tb_events(in_dirs)
+events_dict = tbr.load_tb_events(input_event_dirs)
 
-n_scalars = len(events_dict)
+n_scalars = len(events_dict)  # number of recorded tags. e.g. would be 3 if you'd recorded loss, MAE and R^2
 n_steps, n_events = list(events_dict.values())[0].shape
 
 print(
@@ -74,13 +74,18 @@ print(", ".join(events_dict))
 reduced_events = tbr.reduce_events(events_dict, reduce_ops)
 
 for op in reduce_ops:
-    print(f"Writing '{op}' reduction to '{events_out_dir}-{op}'")
+    print(f"Writing '{op}' reduction to '{tb_events_output_dir}-{op}'")
 
-tbr.write_tb_events(reduced_events, events_out_dir, overwrite)
+tbr.write_tb_events(reduced_events, tb_events_output_dir, overwrite)
 
 print(f"Writing results to '{csv_out_path}'")
 
-tbr.write_df(reduced_events, csv_out_path, overwrite)
+tbr.write_data_file(reduced_events, csv_out_path, overwrite)
 
 print("Reduction complete")
 ```
+
+[`reduce_events`]: <https://github.com/janosh/tensorboard-reducer/blob/6d3468610d2933a23bc355250f9c76e6b6bb0151/tensorboard_reducer/main.py#L12-L14>
+[`load_tb_events`]: https://github.com/janosh/tensorboard-reducer/blob/6d3468610d2933a23bc355250f9c76e6b6bb0151/tensorboard_reducer/load.py#L10-L16
+[`write_data_file`]: https://github.com/janosh/tensorboard-reducer/blob/6d3468610d2933a23bc355250f9c76e6b6bb0151/tensorboard_reducer/write.py#L111-L115
+[`write_tb_events`]: https://github.com/janosh/tensorboard-reducer/blob/6d3468610d2933a23bc355250f9c76e6b6bb0151/tensorboard_reducer/write.py#L45-L49

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,2 @@
+# Python version to use in binder notebooks (see binder link in readme)
 python-3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,11 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     License :: OSI Approved :: MIT License
+project_urls =
+    Package = https://pypi.org/project/tensorboard-reducer
 
 [options]
 packages = find:
@@ -68,3 +72,12 @@ disallow_any_generics = true
 disallow_incomplete_defs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
+
+[pydocstyle]
+convention = google
+# D100: Missing docstring in public module
+# D104: Missing docstring in public package
+# D107: Missing docstring in __init__
+# D205: 1 blank line required between summary line and description
+# D415: First line should end with ., ? or !
+add-ignore = D100,D104,D107,D205,D415

--- a/tensorboard_reducer/__init__.py
+++ b/tensorboard_reducer/__init__.py
@@ -1,3 +1,3 @@
 from .load import load_tb_events
 from .main import main, reduce_events
-from .write import write_df, write_tb_events
+from .write import write_data_file, write_df, write_tb_events

--- a/tensorboard_reducer/load.py
+++ b/tensorboard_reducer/load.py
@@ -14,10 +14,9 @@ def load_tb_events(
     handle_dup_steps: str | None = None,
     min_runs_per_step: int | None = None,
 ) -> dict[str, pd.DataFrame]:
-    """Read the TensorBoard event files matching the provided glob pattern
-    and return their scalar data as a dict with tags ('training/loss',
-    'validation/mae', etc.) as keys and 2d arrays of shape (n_timesteps, r_runs)
-    as values.
+    """Read all TensorBoard event files found in input_dirs and return their scalar data
+    as a dict with tags as keys (e.g. 'training/loss', 'validation/mae') and 2d arrays
+    of shape (n_timesteps, r_runs) as values.
 
     Args:
         input_dirs (list[str]): Directory names containing TensorBoard runs to read

--- a/tensorboard_reducer/main.py
+++ b/tensorboard_reducer/main.py
@@ -6,7 +6,7 @@ from importlib.metadata import version
 import pandas as pd
 
 from .load import load_tb_events
-from .write import write_df, write_tb_events
+from .write import write_data_file, write_tb_events
 
 
 def reduce_events(
@@ -164,7 +164,7 @@ def main(argv: list[str] = None) -> int:
 
     if outpath.endswith(".csv"):
 
-        write_df(reduced_events, outpath, overwrite)
+        write_data_file(reduced_events, outpath, overwrite)
 
         print(f"Wrote {', '.join(reduce_ops)} reductions to '{outpath}'")
 


### PR DESCRIPTION
This is a breaking change. `write_df()` still exists but will now raise `NotImplementedError` to inform users of the rename.