### PR TITLE
Add support for writing reduction results to Excel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install dependencies
         # [test]: see options.extras_require in setup.cfg
-        run: pip install .[test]
+        run: pip install .[test,excel]
 
       - name: Run tests
         id: tests

--- a/assets/python_api_example.ipynb
+++ b/assets/python_api_example.ipynb
@@ -7,6 +7,7 @@
    "outputs": [],
    "source": [
     "from glob import glob\n",
+    "import shutil\n",
     "\n",
     "import tensorboard_reducer as tbr"
    ]
@@ -37,14 +38,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/janosh/.venv/py310/lib/python3.10/site-packages/h5py/__init__.py:36: UserWarning: h5py is running against HDF5 1.12.2 when it was built against 1.12.1, this may cause problems\n",
-      "  _warn((\"h5py is running against HDF5 {0} when it was built against {1}, \"\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -68,8 +61,8 @@
     }
    ],
    "source": [
-    "events_out_dir = \"./tmp/strict\"\n",
-    "csv_out_path = \"./tmp/tb-reduction.csv\"\n",
+    "events_out_dir = \"tmp/reduced\"\n",
+    "csv_out_path = \"tmp/tb-reduction.csv\"\n",
     "overwrite = True\n",
     "reduce_ops = (\"mean\", \"min\", \"max\")\n",
     "\n",
@@ -93,11 +86,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Writing 'mean' reduction to './tmp/strict-mean'\n",
-      "Writing 'min' reduction to './tmp/strict-min'\n",
-      "Writing 'max' reduction to './tmp/strict-max'\n",
-      "Writing results to './tmp/tb-reduction.csv'\n",
-      "Reduction complete\n"
+      "Writing 'mean' reduction to 'tmp/reduced-mean'\n",
+      "Writing 'min' reduction to 'tmp/reduced-min'\n",
+      "Writing 'max' reduction to 'tmp/reduced-max'\n",
+      "Writing results to 'tmp/tb-reduction.csv'\n",
+      "✓ Reduction complete\n"
      ]
     }
    ],
@@ -113,7 +106,17 @@
     "\n",
     "tbr.write_data_file(reduced_events, csv_out_path, overwrite)\n",
     "\n",
-    "print(\"Reduction complete\")"
+    "print(\"✓ Reduction complete\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# clean up\n",
+    "shutil.rmtree('tmp')"
    ]
   }
  ],

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
 # used during pip install .[test]
 [options.extras_require]
 test = pytest; pytest-cov
+excel = openpyxl; xlwt; xlrd
 
 [options.packages.find]
 exclude =

--- a/tensorboard_reducer/main.py
+++ b/tensorboard_reducer/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from importlib.metadata import version
+from typing import Sequence
 
 import pandas as pd
 
@@ -10,7 +11,7 @@ from .write import write_data_file, write_tb_events
 
 
 def reduce_events(
-    events_dict: dict[str, pd.DataFrame], reduce_ops: list[str]
+    events_dict: dict[str, pd.DataFrame], reduce_ops: Sequence[str]
 ) -> dict[str, dict[str, pd.DataFrame]]:
     """Perform numpy reduce ops on the last axis of each array in a dictionary of
     scalar TensorBoard event data. Each array enters

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,3 +17,13 @@ def events_dict() -> dict[str, pd.DataFrame]:
     tb_events_dict = tbr.load_tb_events(glob("tests/runs/strict/run_*"))
 
     return tb_events_dict
+
+
+@pytest.fixture(scope="session")
+def reduced_events(
+    events_dict: dict[str, pd.DataFrame]
+) -> dict[str, dict[str, pd.DataFrame]]:
+
+    reduced_events = tbr.reduce_events(events_dict, REDUCE_OPS)
+
+    return reduced_events

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,19 @@
 from __future__ import annotations
 
-import os
 from glob import glob
 
 import pandas as pd
 import pytest
 
-from tensorboard_reducer import load_tb_events
+import tensorboard_reducer as tbr
+
+REDUCE_OPS = ("mean", "std", "median")
 
 
-# https://docs.pytest.org/en/6.2.x/fixture.html#scope-sharing-fixtures-across-classes-modules-packages-or-session
-# load events_dict once and reuse across test files for speed
-@pytest.fixture(scope="module")
+# load events_dict once and reuse across tests
+# https://docs.pytest.org/en/6.2.x/fixture.html#fixture-scopes
+@pytest.fixture(scope="session")
 def events_dict() -> dict[str, pd.DataFrame]:
-    os.makedirs("tmp", exist_ok=True)
-
-    tb_events_dict = load_tb_events(glob("tests/runs/strict/run_*"))
+    tb_events_dict = tbr.load_tb_events(glob("tests/runs/strict/run_*"))
 
     return tb_events_dict

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from glob import glob
+from pathlib import Path
 
 import py
 import pytest
@@ -12,7 +13,6 @@ from tensorboard_reducer import main
 strict_runs = glob("tests/runs/strict/run_*")
 
 lax_runs = glob("tests/runs/lax/run_*")
-argv_lax = [*lax_runs, "-o", "tmp/lax"]
 
 
 @pytest.mark.parametrize("outpath_flag", ["--outpath", "-o"])
@@ -59,19 +59,13 @@ def test_main_lax(tmpdir: py.path.local) -> None:
     assert [f"{outdir}-mean"] == tmpdir.listdir()
 
 
-def test_main_lax_csv_output() -> None:
-    # make sure we start from clean slate in case prev test failed
-    try:
-        os.remove("tmp/lax.csv")
-    except FileNotFoundError:
-        pass
+def test_main_lax_csv_output(tmp_path: Path) -> None:
+    out_file = f"{tmp_path}/lax.csv"
 
-    main(
-        [*lax_runs, "-o", "tmp/lax.csv", "--lax-tags", "--lax-steps", "-r", "mean,std"]
-    )
+    main([*lax_runs, "-o", out_file, "--lax-tags", "--lax-steps", "-r", "mean,std"])
 
     # make sure CSV file was created
-    os.remove("tmp/lax.csv")
+    assert os.path.isfile(out_file)
 
 
 @pytest.mark.parametrize("arg", ["-v", "--version"])

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -61,6 +61,13 @@ def test_write_data_file(events_dict: dict[str, pd.DataFrame], ext: str) -> None
     os.remove(f"tmp/strict{ext}")
 
 
+def test_write_data_file_with_bad_ext(
+    reduced_events: dict[str, dict[str, pd.DataFrame]]
+) -> None:
+    with pytest.raises(ValueError, match="has unknown extension, should be one of"):
+        tbr.write_data_file(reduced_events, "foo.bad_ext")
+
+
 def test_write_df() -> None:
     with pytest.raises(NotImplementedError, match=r"write_df\(\) was renamed"):
         tbr.write_df(None, "tmp/strict.csv")


### PR DESCRIPTION
Requires additional dependencies `openpyxl` for `.xlsx` and `xlwt` for `.xls` which can be installed individually or at TBR install time using

```sh
pip install 'tensorboard-reducer[excel]'
```