### PR TITLE
DRY workflows

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -8,10 +8,4 @@ on:
 
 jobs:
   markdown-link-check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v3
-
-      - name: Run markdown link check
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+    uses: janosh/workflows/.github/workflows/markdown-link-check.yml@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: Tests
 on:
   push:
     branches: [main]
-    paths: ['**/*.py', '.github/workflows/test.yml']
+    paths: ["**/*.py", ".github/workflows/test.yml"]
   pull_request:
     branches: [main]
-    paths: ['**/*.py', '.github/workflows/test.yml']
+    paths: ["**/*.py", ".github/workflows/test.yml"]
   release:
     types: [published, edited]
 
@@ -15,41 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v3
-
-      - name: Set up python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Install dependencies
-        # see options.extras_require in setup.cfg
-        run: pip install .[test,excel]
-
-      - name: Run tests
-        id: tests
-        run: pytest --durations 0 --cov .
-
-  release:
-    runs-on: ubuntu-latest
-    needs: tests
-    if: github.event_name == 'release' && needs.tests.result == 'success'
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v3
-
-      - name: Build and upload dist
-        run: |
-          pip install build twine
-          python -m build
-          twine check dist/* --strict
-          twine upload --skip-existing --repository-url https://upload.pypi.org/legacy/ dist/*.tar.gz
-        env:
-          TWINE_USERNAME: janosh
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+    uses: janosh/workflows/.github/workflows/pytest-release.yml@main
+    with:
+      os: ${{ matrix.os }}
+      install-cmd: pip install .[test,excel]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,13 +7,13 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.259
+    rev: v0.0.260
     hooks:
       - id: ruff
         args: [--fix]
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black-jupyter
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ select = [
   "B",   # flake8-bugbear
   "D",   # pydocstyle
   "E",   # pycodestyle
-  "ERA", # flake8-eradicate
   "F",   # pyflakes
   "I",   # isort
   "PLE", # pylint error

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 [![PyPI Downloads](https://img.shields.io/pypi/dm/tensorboard-reducer)](https://pypistats.org/packages/tensorboard-reducer)
 [![DOI](https://zenodo.org/badge/354585417.svg)](https://zenodo.org/badge/latestdoi/354585417)
 
-> For a similar project built for TensorFlow rather than PyTorch, see [`tensorboard-aggregator`](https://github.com/Spenhouet/tensorboard-aggregator).
+> This project can ingest both PyTorch and TensorFlow event files but was mostly tested with PyTorch. For a TF-only project, see [`tensorboard-aggregator`](https://github.com/Spenhouet/tensorboard-aggregator).
 
 Compute statistics (`mean`, `std`, `min`, `max`, `median` or any other [`numpy` operation](https://numpy.org/doc/stable/reference/routines.statistics)) of multiple TensorBoard run directories. This can be used e.g. when training model ensembles to reduce noise in loss/accuracy/error curves and establish statistical significance of performance improvements or get a better idea of epistemic uncertainty. Results can be saved to disk either as new TensorBoard runs or CSV/JSON/Excel. More file formats are easy to add, PRs welcome.
 
@@ -24,7 +24,7 @@ Compute statistics (`mean`, `std`, `min`, `max`, `median` or any other [`numpy` 
 [codespace url]: https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=354585417
 [Open in Google Colab]: https://colab.research.google.com/assets/colab-badge.svg
 
-_The mean of 3 runs shown in pink here is less noisy and better suited for comparisons between models or different training techniques than individual runs._
+*The mean of 3 runs shown in pink here is less noisy and better suited for comparisons between models or different training techniques than individual runs.*
 ![Mean of 3 TensorBoard logs](https://raw.githubusercontent.com/janosh/tensorboard-reducer/main/assets/3-runs-mean.png)
 
 ## Installation

--- a/tensorboard_reducer/__init__.py
+++ b/tensorboard_reducer/__init__.py
@@ -1,6 +1,7 @@
 from tensorboard_reducer.load import load_tb_events as load_tb_events
 from tensorboard_reducer.main import main as main
 from tensorboard_reducer.main import reduce_events as reduce_events
+from tensorboard_reducer.reduce import reduce_events as reduce_events
 from tensorboard_reducer.write import write_data_file as write_data_file
 from tensorboard_reducer.write import write_df as write_df
 from tensorboard_reducer.write import write_tb_events as write_tb_events

--- a/tensorboard_reducer/main.py
+++ b/tensorboard_reducer/main.py
@@ -2,49 +2,10 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from importlib.metadata import version
-from typing import Sequence
-
-import pandas as pd
 
 from tensorboard_reducer.load import load_tb_events
+from tensorboard_reducer.reduce import reduce_events
 from tensorboard_reducer.write import write_data_file, write_tb_events
-
-
-def reduce_events(
-    events_dict: dict[str, pd.DataFrame],
-    reduce_ops: Sequence[str],
-    verbose: bool = False,
-) -> dict[str, dict[str, pd.DataFrame]]:
-    """Perform numpy reduce operations along the last dimension of each array in a
-    dictionary of scalar TensorBoard event data. Each array (1 per run) enters this
-    function with shape (n_steps, n_runs) and it returns a dict of len(reduce_ops)
-    subdicts each with keys named after scalar quantities (loss, accuracy, etc.) holding
-    arrays with shape (n_steps,).
-
-    Args:
-        events_dict (dict[str, pd.DataFrame]): Dict of arrays to reduce.
-        reduce_ops (list[str]): Names of numpy reduce ops. E.g. mean, std, min, max, ...
-        verbose (bool, optional): Whether to print progress. Defaults to False.
-
-    Returns:
-        dict[str, dict[str, pd.DataFrame]]: Dict of dicts where each subdict holds one
-            reduced array for each of the specified reduce ops, e.g.
-            {"loss": {"mean": arr.mean(-1), "std": arr.std(-1)}}.
-    """
-    reductions: dict[str, dict[str, pd.DataFrame]] = {}
-
-    for op in reduce_ops:
-        reductions[op] = {}
-
-        for tag, df in events_dict.items():
-            reductions[op][tag] = getattr(df, op)(axis=1)
-
-    if verbose:
-        print(
-            f"Reduced {len(events_dict)} scalars with {len(reduce_ops)} operations:"
-            f" ({', '.join(reduce_ops)})"
-        )
-    return reductions
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tensorboard_reducer/reduce.py
+++ b/tensorboard_reducer/reduce.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import pandas as pd
+
+
+def reduce_events(
+    events_dict: dict[str, pd.DataFrame],
+    reduce_ops: Sequence[str],
+    verbose: bool = False,
+) -> dict[str, dict[str, pd.DataFrame]]:
+    """Perform numpy reduce operations along the last dimension of each array in a
+    dictionary of scalar TensorBoard event data. Each array (1 per run) enters this
+    function with shape (n_steps, n_runs) and it returns a dict of len(reduce_ops)
+    subdicts each with keys named after scalar quantities (loss, accuracy, etc.) holding
+    arrays with shape (n_steps,).
+
+    Args:
+        events_dict (dict[str, pd.DataFrame]): Dict of arrays to reduce.
+        reduce_ops (list[str]): Names of numpy reduce ops. E.g. mean, std, min, max, ...
+        verbose (bool, optional): Whether to print progress. Defaults to False.
+
+    Returns:
+        dict[str, dict[str, pd.DataFrame]]: Dict of dicts where each subdict holds one
+            reduced array for each of the specified reduce ops, e.g.
+            {"loss": {"mean": arr.mean(-1), "std": arr.std(-1)}}.
+    """
+    reductions: dict[str, dict[str, pd.DataFrame]] = {}
+
+    for op in reduce_ops:
+        reductions[op] = {}
+
+        for tag, df in events_dict.items():
+            reductions[op][tag] = getattr(df, op)(axis=1)
+
+    if verbose:
+        print(
+            f"Reduced {len(events_dict)} scalars with {len(reduce_ops)} operations:"
+            f" ({', '.join(reduce_ops)})"
+        )
+    return reductions

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -1,18 +1,33 @@
 from __future__ import annotations
 
+from typing import Sequence
+
+import numpy as np
 import pandas as pd
 import pytest
 
 from tensorboard_reducer import reduce_events
 
 
+def generate_sample_data(
+    n_tags: int = 1, n_runs: int = 10, n_steps: int = 5
+) -> dict[str, pd.DataFrame]:
+    events_dict = {}
+    for idx in range(n_tags):
+        data = np.random.random((n_steps, n_runs))
+        df = pd.DataFrame(data, columns=[f"run_{j}" for j in range(n_runs)])
+        events_dict[f"tag_{idx}"] = df
+    return events_dict
+
+
 @pytest.mark.parametrize("verbose", [True, False])
+@pytest.mark.parametrize("reduce_ops", [["mean"], ["max", "min"], ["std", "median"]])
 def test_reduce_events(
     events_dict: dict[str, pd.DataFrame],
+    reduce_ops: Sequence[str],
     verbose: bool,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    reduce_ops = ["mean", "std", "max", "min"]
     reduced_events = reduce_events(events_dict, reduce_ops, verbose=verbose)
 
     out_keys = list(reduced_events)
@@ -35,13 +50,14 @@ def test_reduce_events(
 
             assert (
                 n_steps == out_steps
-            ), f"length mismatch in initial ({n_steps}) and reduced ({out_steps}) steps"
+            ), f"length mismatch in initial={n_steps} and reduced={out_steps} steps"
 
-    min_data = reduced_events["min"]["strict/foo"]
-    max_data = reduced_events["max"]["strict/foo"]
-    assert all(
-        min_data <= max_data
-    ), "min reduction was not <= max reduction at every step"
+    if {"min", "max"} <= set(reduce_ops):
+        min_data = reduced_events["min"]["strict/foo"]
+        max_data = reduced_events["max"]["strict/foo"]
+        assert all(
+            min_data <= max_data
+        ), "min reduction was not <= max reduction at every step"
 
     stdout, stderr = capsys.readouterr()
     assert stderr == ""
@@ -52,3 +68,28 @@ def test_reduce_events(
         ) in stdout
     else:
         assert stdout == ""
+
+
+@pytest.mark.parametrize("n_tags, n_runs, n_steps", [(1, 10, 5), (2, 5, 3), (3, 3, 10)])
+def test_reduce_events_dimensions(n_tags: int, n_runs: int, n_steps: int) -> None:
+    events_dict = generate_sample_data(n_tags=n_tags, n_runs=n_runs, n_steps=n_steps)
+    reduce_ops = ["mean", "std", "max", "min"]
+    reduced_events = reduce_events(events_dict, reduce_ops)
+
+    for op, reduced_dict in reduced_events.items():
+        assert len(reduced_dict) == n_tags, (
+            f"mismatch in number of tags for operation {op}: "
+            f"expected {n_tags}, found {len(reduced_dict)}"
+        )
+
+        for tag, reduced_df in reduced_dict.items():
+            assert len(reduced_df) == n_steps, (
+                f"length mismatch in initial={n_steps} vs reduced={len(reduced_df)}"
+                f" steps for tag {tag} and operation {op}"
+            )
+
+
+@pytest.mark.parametrize("reduce_ops", [["mean"], ["max", "min"], ["std", "median"]])
+def test_reduce_events_empty_input(reduce_ops: Sequence[str]) -> None:
+    reduced_events = reduce_events({}, reduce_ops)
+    assert reduced_events == dict.fromkeys(reduce_ops, {})


### PR DESCRIPTION
Migrate to reusable workflows in https://github.com/janosh/workflows.

 e4cd173 DRY workflows
 4892024 tweak readme note re `tensorboard-aggregator`
 34f0a45 move `reduce_events()` to new module `reduce.py`
 30e1022 ruff ignore `flake8-eradicate`
 f6e2efe add tests 'test_reduce_events_dimensions' and 'test_reduce_events_empty_input'

