### PR TITLE
Ignore tag order while checking their occurrences (strict_tags)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,18 +7,18 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.284
+    rev: v0.0.290
     hooks:
       - id: ruff
         args: [--fix]
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
       - id: black-jupyter
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.0
+    rev: v1.5.1
     hooks:
       - id: mypy
 

--- a/tensorboard_reducer/load.py
+++ b/tensorboard_reducer/load.py
@@ -71,16 +71,18 @@ def load_tb_events(
     # strict_tags=False.
     if strict_tags:
         # generate list of scalar tags for all event files each in alphabetical order
-        all_dirs_tags_list = sorted(
-            accumulator.scalar_tags for accumulator in accumulators
-        )
+        tags_in_each_dir = [
+            set(accumulator.scalar_tags) for accumulator in accumulators
+        ]
 
-        tags_set = {tag for tags in all_dirs_tags_list for tag in tags}
+        all_tags = {tag for tags in tags_in_each_dir for tag in tags}
 
+        # generate report of missing tags for each run directory
+        # will be empty string if no tags are missing
         missing_tags_report = "".join(
-            f"- {in_dir} missing tags: {', '.join(tags_set - {*tags})}\n"
-            for in_dir, tags in zip(input_dirs, all_dirs_tags_list)
-            if len(tags_set - {*tags}) > 0
+            f"- {in_dir} missing tags: {', '.join(all_tags - run_tags)}\n"
+            for in_dir, run_tags in zip(input_dirs, tags_in_each_dir)
+            if len(all_tags - run_tags) > 0
         )
 
         if missing_tags_report:

--- a/tensorboard_reducer/load.py
+++ b/tensorboard_reducer/load.py
@@ -70,13 +70,8 @@ def load_tb_events(
     # Safety check: make sure all loaded runs have identical tags unless user set
     # strict_tags=False.
     if strict_tags:
-        # generate list of scalar tags for all event files each in alphabetical order
-        all_dirs_tags_list = sorted(
-            accumulator.scalar_tags for accumulator in accumulators
-        )
-        first_tags = all_dirs_tags_list[0]
-
-        all_runs_same_tags = all(first_tags == tags for tags in all_dirs_tags_list)
+        # generate list of scalar tags for all event files
+        all_dirs_tags_list = [accumulator.scalar_tags for accumulator in accumulators]
 
         tags_set = {tag for tags in all_dirs_tags_list for tag in tags}
 
@@ -86,7 +81,7 @@ def load_tb_events(
             if len(tags_set - {*tags}) > 0
         )
 
-        if not all_runs_same_tags:
+        if missing_tags_report:
             raise ValueError(
                 f"Some tags are in some logs but not others:\n{missing_tags_report}"
                 "\nIf intentional, pass CLI flag --lax-tags or strict_tags=False "

--- a/tensorboard_reducer/load.py
+++ b/tensorboard_reducer/load.py
@@ -70,8 +70,10 @@ def load_tb_events(
     # Safety check: make sure all loaded runs have identical tags unless user set
     # strict_tags=False.
     if strict_tags:
-        # generate list of scalar tags for all event files
-        all_dirs_tags_list = [accumulator.scalar_tags for accumulator in accumulators]
+        # generate list of scalar tags for all event files each in alphabetical order
+        all_dirs_tags_list = sorted(
+            accumulator.scalar_tags for accumulator in accumulators
+        )
 
         tags_set = {tag for tags in all_dirs_tags_list for tag in tags}
 


### PR DESCRIPTION
Thanks for the great work.

I got just a small issue with the following code snippet:

https://github.com/janosh/tensorboard-reducer/blob/1ace02f8c54dfd734e9b5bc2913b3389bb4386fe/tensorboard_reducer/load.py#L70-L97

My problem is that (maybe due to paralism) the tags are not always in the same order.

For example `all_runs_same_tags` could result in something like this:
```python
[
    ['b', 'a'],
    ['a', 'b']
]
```

Unfortunatelly, line 79 requires them in the same order and the sort before does not sort the second dimension of the array. In the example above it would just swap the lines due to the content of the first element of each line.

The error message in this case is the default error text with an empty `missing_tags_report`:
```text
ValueError: Some tags appear only in some logs but not others:

If this is intentional, pass --lax-tags to the CLI or strict_tags=False to the Python API. After that, each tag reduction will run over as many runs as are available for a given tag, even if that's just one. Proceed with caution as not all tags will have the same statistics in downstream analysis.
```

Therefore, I would like to propose to check `missing_tags_report` instead of `all_runs_same_tags`.

----

An alternative would be to use sets:
```python
first_tags = set(all_dirs_tags_list[0])

all_runs_same_tags = all(first_tags == set(tags) for tags in all_dirs_tags_list)
```